### PR TITLE
new(component): GitHubBadge

### DIFF
--- a/components/GitHubBadge/GitHubBadge.mdx
+++ b/components/GitHubBadge/GitHubBadge.mdx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export const GitHubBadge = ({ owner, repo, workflow, branch = "main" }) => {
+  const badgeUrl = `https://github.com/${owner}/${repo}/actions/workflows/${workflow}/badge.svg?branch=${branch}`;
+
+  return (
+     <img src={badgeUrl} alt={`${workflow} status`} className="h-6" />
+  );
+};
+
+<GitHubBadge owner="readmeio" repo="rdme" workflow="release.yml" branch="main" />

--- a/components/GitHubBadge/readme.md
+++ b/components/GitHubBadge/readme.md
@@ -1,0 +1,18 @@
+# `GitHubBadge`
+
+## Overview
+
+This component displays a badge that links to a GitHub actions workflow status. It is useful for showing the status of a CI/CD pipeline or other automated workflows.
+
+## Usage
+
+The `GitHubBadge` component accepts the following props:
+
+- `owner` (string, required): The GitHub username or organization name that owns the repository.
+- `repo` (string, required): The repository name where workflow is located.
+- `workflow` (string, required): The name of the workflow file (e.g., `ci.yml`, `release.yml`).
+- `branch` (string, default: "main"): The branch name to display the badge for.
+
+```jsx
+<GitHubBadge owner='readmeio' repo='rdme' workflow='release.yml' branch='main' />
+```


### PR DESCRIPTION
## `<GitHubBadge>` 

Describe your new component or updates here.

# `GitHubBadge`

## Overview

This component displays a badge that links to a GitHub actions workflow status. It is useful for showing the status of a CI/CD pipeline or other automated workflows.

## Usage

The `GitHubBadge` component accepts the following props:

- `owner` (string, required): The GitHub username or organization name that owns the repository.
- `repo` (string, required): The repository name where workflow is located.
- `workflow` (string, required): The name of the workflow file (e.g., `ci.yml`, `release.yml`).
- `branch` (string, default: "main"): The branch name to display the badge for.

```jsx
<GitHubBadge owner='readmeio' repo='rdme' workflow='release.yml' branch='main' />
```

