### PR TITLE
feat: Latex component

### DIFF
--- a/components/Latex/Latex.mdx
+++ b/components/Latex/Latex.mdx
@@ -9,7 +9,14 @@ export const Latex = ({ children }) => {
     })
   }, [children]);
 
-  return content;
- }
+  return(
+    <>
+      <link href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css" rel="stylesheet" />
+      {content}
+    </>
+  )
+}
 
-<Latex>We give illustrations for the {1 + 2} processes $e^+e^-$, gluon-gluon and $\\gamma\\gamma \\to W t\\bar b$.</Latex>
+<Latex>{`
+  We give illustrations for the ${1 + 2} processes $e^+e^-$, gluon-gluon and $\\gamma\\gamma \\to W t\\bar b$.
+`}</Latex>

--- a/components/Latex/Latex.mdx
+++ b/components/Latex/Latex.mdx
@@ -4,10 +4,10 @@ export const Latex = ({ children }) => {
   const [content, setContent] = useState(children);
 
   useEffect(() => {
-    import("https://cdn.jsdelivr.net/npm/react-latex-next@3.0.0/+esm").then(Module => {
+    import('https://cdn.jsdelivr.net/npm/react-latex-next@3.0.0/+esm').then(Module => {
       setContent(() => <Module.default>{children}</Module.default>)
     })
-  }, []);
+  }, [children]);
 
   return content;
  }

--- a/components/Latex/Latex.mdx
+++ b/components/Latex/Latex.mdx
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+
+export const Latex = ({ children }) => {
+  const [content, setContent] = useState(children);
+
+  useEffect(() => {
+    import("https://cdn.jsdelivr.net/npm/react-latex-next@3.0.0/+esm").then(Module => {
+      setContent(() => <Module.default>{children}</Module.default>)
+    })
+  }, []);
+
+  return content;
+ }
+
+<Latex>We give illustrations for the {1 + 2} processes $e^+e^-$, gluon-gluon and $\\gamma\\gamma \\to W t\\bar b$.</Latex>

--- a/components/Latex/readme.md
+++ b/components/Latex/readme.md
@@ -1,0 +1,14 @@
+# `<Latex />`
+
+## Overview
+
+A component to render LaTeX syntax. (**Note**: this will fetch the `react-latex-next` package from a CDN on page load.)
+
+## Usage
+
+```mdx
+<Latex>{`
+  We give illustrations for the ${1 + 2} processes $e^+e^-$, gluon-gluon and
+  $\\gamma\\gamma \\to W t\\bar b$.
+`}</Latex>
+```


### PR DESCRIPTION
## `<Latex>`

Adds a component to fetch `react-latex-next` and render LaTeX docs.

### Usage

```mdx
<Latex>
  We give illustrations for the {1 + 2} processes $e^+e^-$, gluon-gluon and
  $\\gamma\\gamma \\to W t\\bar b$.
</Latex>
```
