### PR TITLE
Adding the 'Run in Postman' button

### DIFF
--- a/components/PostmanRunButton/PostmanRunButton.mdx
+++ b/components/PostmanRunButton/PostmanRunButton.mdx
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react';
+
+export const PostmanRunButton = ({ 
+  collectionId = "", // Add your collection ID here
+  collectionUrl = "", // Add your collection URL here
+  visibility = "public", 
+  action = "collection/fork"
+}) => {
+  useEffect(() => {
+    // Only run on client-side
+    if (typeof window !== 'undefined') {
+      const scriptFunction = function (p,o,s,t,m,a,n) {
+        !p[s] && (p[s] = function () { (p[t] || (p[t] = [])).push(arguments); });
+        !o.getElementById(s+t) && o.getElementsByTagName("head")[0].appendChild((
+          (n = o.createElement("script")),
+          (n.id = s+t), (n.async = 1), (n.src = m), n
+        ));
+      };
+      
+      // Execute the script function directly
+      scriptFunction(window, document, "_pm", "PostmanRunObject", "https://run.pstmn.io/button.js");
+      
+      return () => {
+        // Cleanup if needed
+        const scriptElement = document.getElementById('_pmPostmanRunObject');
+        if (scriptElement) document.head.removeChild(scriptElement);
+      };
+    }
+  }, []);
+
+  return (
+    <div className="my-4">
+      <div 
+        className="postman-run-button"
+        data-postman-action={action}
+        data-postman-visibility={visibility}
+        data-postman-var-1={collectionId}
+        data-postman-collection-url={collectionUrl}
+      />
+    </div>
+  );
+};
+
+{/* Example usage - replace with your actual Postman collection details */}
+<PostmanRunButton 
+  collectionId="123456-abcd-efgh-ijkl" 
+  collectionUrl="entityId=123456-abcd-efgh-ijkl&entityType=collection&workspaceId=abcdef-1234-5678"
+/> 

--- a/components/PostmanRunButton/PostmanRunButton.mdx
+++ b/components/PostmanRunButton/PostmanRunButton.mdx
@@ -9,7 +9,7 @@ export const PostmanRunButton = ({
   useEffect(() => {
     // Only run on client-side
     if (typeof window !== 'undefined') {
-      const scriptFunction = function (p, o, s, t, m, a, n) {
+      const scriptFunction = function (p, o, s, t, m) {
         if (!p[s]) {
           p[s] = function (...args) { 
             const postmanRunObject = p[t] || (p[t] = []);

--- a/components/PostmanRunButton/PostmanRunButton.mdx
+++ b/components/PostmanRunButton/PostmanRunButton.mdx
@@ -1,24 +1,32 @@
 import React, { useEffect } from 'react';
 
 export const PostmanRunButton = ({ 
-  collectionId = "", // Add your collection ID here
-  collectionUrl = "", // Add your collection URL here
-  visibility = "public", 
-  action = "collection/fork"
+  collectionId = '', // Add your collection ID here
+  collectionUrl = '', // Add your collection URL here
+  visibility = 'public', 
+  action = 'collection/fork'
 }) => {
   useEffect(() => {
     // Only run on client-side
     if (typeof window !== 'undefined') {
-      const scriptFunction = function (p,o,s,t,m,a,n) {
-        !p[s] && (p[s] = function () { (p[t] || (p[t] = [])).push(arguments); });
-        !o.getElementById(s+t) && o.getElementsByTagName("head")[0].appendChild((
-          (n = o.createElement("script")),
-          (n.id = s+t), (n.async = 1), (n.src = m), n
-        ));
+      const scriptFunction = function (p, o, s, t, m, a, n) {
+        if (!p[s]) {
+          p[s] = function (...args) { 
+            const postmanRunObject = p[t] || (p[t] = []);
+            postmanRunObject.push(args); 
+          };
+        }
+        if (!o.getElementById(s + t)) {
+          const scriptElement = o.createElement('script');
+          scriptElement.id = s + t;
+          scriptElement.async = 1;
+          scriptElement.src = m;
+          o.getElementsByTagName('head')[0].appendChild(scriptElement);
+        }
       };
       
       // Execute the script function directly
-      scriptFunction(window, document, "_pm", "PostmanRunObject", "https://run.pstmn.io/button.js");
+      scriptFunction(window, document, '_pm', 'PostmanRunObject', 'https://run.pstmn.io/button.js');
       
       return () => {
         // Cleanup if needed
@@ -26,6 +34,7 @@ export const PostmanRunButton = ({
         if (scriptElement) document.head.removeChild(scriptElement);
       };
     }
+    return undefined;
   }, []);
 
   return (

--- a/components/PostmanRunButton/PostmanRunButton.mdx
+++ b/components/PostmanRunButton/PostmanRunButton.mdx
@@ -50,7 +50,6 @@ export const PostmanRunButton = ({
   );
 };
 
-{/* Example usage - replace with your actual Postman collection details */}
 <PostmanRunButton 
   collectionId="123456-abcd-efgh-ijkl" 
   collectionUrl="entityId=123456-abcd-efgh-ijkl&entityType=collection&workspaceId=abcdef-1234-5678"

--- a/components/PostmanRunButton/readme.md
+++ b/components/PostmanRunButton/readme.md
@@ -1,0 +1,26 @@
+# Postman Run Button Component
+
+Adds a Postman Run Button to your documentation, allowing users to fork a Postman collection.
+
+### Usage
+
+```mdx
+<PostmanRunButton 
+  collectionId="123456-abcd-efgh-ijkl" 
+  collectionUrl="entityId=123456-abcd-efgh-ijkl&entityType=collection&workspaceId=abcdef-1234-5678"
+/>
+```
+
+### How to Find Your Collection ID and URL
+
+1. Open your collection in Postman
+2. Click "Share" button at the top right of your collection
+3. Go to the "Via API" tab
+4. You'll find your Collection ID in the URL or in the API response
+5. The Collection URL contains parameters after the main URL (starting with "entityId=")
+
+### Props
+
+- `collectionId` (required): The ID of your Postman collection (e.g., "123456-abcd-efgh-ijkl")
+- `collectionUrl` (required): The URL parameters for your collection, typically in this format: 
+  `entityId=YOUR_COLLECTION_ID&entityType=collection&workspaceId=YOUR_WORKSPACE_ID`


### PR DESCRIPTION
# Postman Run Button Component

Adds a Postman Run Button to your documentation, allowing users to fork a Postman collection. Basically a deconstructed version of https://learning.postman.com/docs/publishing-your-api/run-in-postman/creating-run-button/

### Usage

```mdx
<PostmanRunButton 
  collectionId="123456-abcd-efgh-ijkl" 
  collectionUrl="entityId=123456-abcd-efgh-ijkl&entityType=collection&workspaceId=abcdef-1234-5678"
/>
```

### How to Find Your Collection ID and URL

1. Open your collection in Postman
2. Click "Share" button at the top right of your collection
3. Go to the "Via API" tab
4. You'll find your Collection ID in the URL or in the API response
5. The Collection URL contains parameters after the main URL (starting with "entityId=")

### Props

- `collectionId` (required): The ID of your Postman collection (e.g., "123456-abcd-efgh-ijkl")
- `collectionUrl` (required): The URL parameters for your collection, typically in this format: 
  `entityId=YOUR_COLLECTION_ID&entityType=collection&workspaceId=YOUR_WORKSPACE_ID`